### PR TITLE
avoids the need to import extension properties

### DIFF
--- a/alpaka/plugin/src/main/java/ch/ubique/gradle/alpaka/AlpakaPlugin.kt
+++ b/alpaka/plugin/src/main/java/ch/ubique/gradle/alpaka/AlpakaPlugin.kt
@@ -3,7 +3,6 @@
 package ch.ubique.gradle.alpaka
 
 import ch.ubique.gradle.alpaka.config.AlpakaPluginConfig
-import ch.ubique.gradle.alpaka.extensions.applicationvariant.launcherIconLabel
 import ch.ubique.gradle.alpaka.extensions.capitalize
 import ch.ubique.gradle.alpaka.extensions.getMergedManifestFile
 import ch.ubique.gradle.alpaka.extensions.listFilesOrEmpty
@@ -23,6 +22,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Provider
+import org.gradle.kotlin.dsl.launcherIconLabel
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
 import java.io.File
 import ch.ubique.gradle.alpaka.extensions.productflavor.launcherIconLabel as flavorLauncherIconLabel

--- a/alpaka/plugin/src/main/java/ch/ubique/gradle/alpaka/extensions/applicationvariant/ApplicationVariantDimensionExtensions.kt
+++ b/alpaka/plugin/src/main/java/ch/ubique/gradle/alpaka/extensions/applicationvariant/ApplicationVariantDimensionExtensions.kt
@@ -4,20 +4,13 @@ import com.android.build.api.dsl.ApplicationVariantDimension
 import org.gradle.api.plugins.ExtensionAware
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
 
-private fun <T> ApplicationVariantDimension.setProperty(key: String, value: T) {
+internal fun <T> ApplicationVariantDimension.setProperty(key: String, value: T) {
 	val extensionAware = this as ExtensionAware
 	extensionAware.extraProperties[key] = value
 }
 
-private fun <T> ApplicationVariantDimension.getProperty(key: String): T {
+@Suppress("UNCHECKED_CAST")
+internal fun <T> ApplicationVariantDimension.getProperty(key: String): T {
 	val extensionAware = this as ExtensionAware
 	return extensionAware.extraProperties[key] as T
 }
-
-var ApplicationVariantDimension.launcherIconLabel: String?
-	get() = getProperty("launcherIconLabel")
-	set(value) = setProperty("launcherIconLabel", value)
-
-var ApplicationVariantDimension.alpakaUploadKey: String?
-	get() = getProperty("alpakaUploadKey")
-	set(value) = setProperty("alpakaUploadKey", value)

--- a/alpaka/plugin/src/main/java/org/gradle/kotlin/dsl/AlpakaDsl.kt
+++ b/alpaka/plugin/src/main/java/org/gradle/kotlin/dsl/AlpakaDsl.kt
@@ -1,0 +1,13 @@
+package org.gradle.kotlin.dsl
+
+import ch.ubique.gradle.alpaka.extensions.applicationvariant.getProperty
+import ch.ubique.gradle.alpaka.extensions.applicationvariant.setProperty
+import com.android.build.api.dsl.ApplicationVariantDimension
+
+var ApplicationVariantDimension.launcherIconLabel: String?
+	get() = getProperty("launcherIconLabel")
+	set(value) = setProperty("launcherIconLabel", value)
+
+var ApplicationVariantDimension.alpakaUploadKey: String?
+	get() = getProperty("alpakaUploadKey")
+	set(value) = setProperty("alpakaUploadKey", value)

--- a/examplekts/build.gradle.kts
+++ b/examplekts/build.gradle.kts
@@ -1,6 +1,3 @@
-import ch.ubique.gradle.alpaka.extensions.applicationvariant.alpakaUploadKey
-import ch.ubique.gradle.alpaka.extensions.applicationvariant.launcherIconLabel
-
 plugins {
 	alias(libs.plugins.androidApplication)
 	alias(libs.plugins.kotlinAndroid)


### PR DESCRIPTION
by moving them to the `org.gradle.kotlin.dsl` package.

Depends on https://github.com/UbiqueInnovation/gradle-plugin-alpaka-android/pull/8