### PR TITLE
agp 8.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The plugin contains the following functionality:
 
 ```kotlin
 plugins {
-    id("ch.ubique.gradle.alpaka") version "8.7.0"
+    id("ch.ubique.gradle.alpaka") version "8.9.0"
 }
 ```
 

--- a/alpaka/gradle/wrapper/gradle-wrapper.properties
+++ b/alpaka/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examplegroovy/build.gradle
+++ b/examplegroovy/build.gradle
@@ -6,12 +6,12 @@ plugins {
 
 android {
 	namespace 'com.example.examplegroovy'
-	compileSdk 34
+	compileSdk 35
 
 	defaultConfig {
 		applicationId "com.example.examplegroovy"
 		minSdk 26
-		targetSdk 34
+		targetSdk 35
 		versionCode 1
 		versionName "1.0"
 

--- a/examplekts/build.gradle.kts
+++ b/examplekts/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
 	namespace = "com.example.examplekts"
-	compileSdk = 34
+	compileSdk = 35
 
 	defaultConfig {
 		applicationId = "com.example.examplekts"
 		minSdk = 26
-		targetSdk = 34
+		targetSdk = 35
 		versionCode = 1
 		versionName = "1.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,18 @@
 [versions]
-agp = "8.8.0"
+agp = "8.9.0"
 kotlin = "2.1.10"
 pluginPublish = "1.2.2"
 vanniktech = "0.29.0"
 
 okhttp = "4.12.0"
 retrofit = "2.11.0"
-moshi = "1.15.1"
+moshi = "1.15.2"
 
-coreKtx = "1.13.1"
+coreKtx = "1.15.0"
 appcompat = "1.7.0"
 material = "1.12.0"
-activity = "1.9.2"
-constraintlayout = "2.1.4"
+activity = "1.10.1"
+constraintlayout = "2.2.1"
 
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin"}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This pull request includes several updates to the project dependencies and configurations. The most important changes include updating the Gradle plugin version, updating the Gradle distribution URL, and updating the Android SDK versions.

Dependency and configuration updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R24): Updated the Gradle plugin version from `8.7.0` to `8.9.0`.
* [`gradle/wrapper/gradle-wrapper.properties`](diffhunk://#diff-b8f360a4dc8a7e046743599b01675c78a40ae84fcade27ab769e2b744b8875c5L3-R3): Updated the Gradle distribution URL to `https://services.gradle.org/distributions/gradle-8.11.1-all.zip`.
* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL2-R15): Updated various dependencies, including AGP to `8.9.0`, Moshi to `1.15.2`, coreKtx to `1.15.0`, activity to `1.10.1`, and constraintlayout to `2.2.1`.

Android SDK updates:

* [`examplegroovy/build.gradle`](diffhunk://#diff-563351bbb8dd19c540bffdd5fd7d8dc020589e0e66f646b9f525163af0cbebd2L9-R14): Updated `compileSdk` and `targetSdk` versions to `35`.
* [`examplekts/build.gradle.kts`](diffhunk://#diff-a5bbc74df788d4fa38feb5f6ec248dcdb3a59fa9ccea5825d7cb4691b5210c3eL9-R14): Updated `compileSdk` and `targetSdk` versions to `35`.