### PR TITLE
agp 8.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The plugin contains the following functionality:
 
 ```kotlin
 plugins {
-    id("ch.ubique.gradle.alpaka") version "8.10.0"
+    id("ch.ubique.gradle.alpaka") version "8.11.0"
 }
 ```
 

--- a/alpaka/gradle/wrapper/gradle-wrapper.properties
+++ b/alpaka/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.10.0"
-kotlin = "2.1.10"
+agp = "8.11.0"
+kotlin = "2.1.21"
 pluginPublish = "1.2.2"
 vanniktech = "0.29.0"
 
@@ -8,8 +8,8 @@ okhttp = "4.12.0"
 retrofit = "2.11.0"
 moshi = "1.15.2"
 
-coreKtx = "1.15.0"
-appcompat = "1.7.0"
+coreKtx = "1.16.0"
+appcompat = "1.7.1"
 material = "1.12.0"
 activity = "1.10.1"
 constraintlayout = "2.2.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This pull request updates dependencies and configurations to use newer versions of Gradle, Kotlin, and other libraries. The changes ensure compatibility with the latest features and improvements while maintaining consistency across the project.

### Dependency and version updates:

* Updated the `alpaka` plugin version from `8.10.0` to `8.11.0` in `README.md` (`plugins` block).
* Updated the Gradle distribution URL to use version `8.14.2` (from `8.11.1`).
* Updated library versions in `gradle/libs.versions.toml`:
  - Kotlin from `2.1.10` to `2.1.21`.
  - Core KTX from `1.15.0` to `1.16.0`.
  - AppCompat from `1.7.0` to `1.7.1`.