### PR TITLE
Update AGP to 9.2.0 and Gradle wrapper to 9.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The plugin contains the following functionality:
 
 ```kotlin
 plugins {
-    id("ch.ubique.gradle.alpaka") version "9.1.0"
+    id("ch.ubique.gradle.alpaka") version "9.2.0"
 }
 ```
 

--- a/alpaka/gradle/wrapper/gradle-wrapper.properties
+++ b/alpaka/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.1.0"
+agp = "9.2.0"
 kotlin = "2.2.10"
 pluginPublish = "2.1.1"
 vanniktech = "0.36.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

- Bump Android Gradle Plugin from 9.1.0 to 9.2.0 in gradle/libs.versions.toml
- Bump Gradle wrapper from 9.3.1 to 9.4.1 in gradle/wrapper/gradle-wrapper.properties
- Update plugin version reference in README.md from 9.1.0 to 9.2.0 (tracks AGP major.minor by convention)