### PR TITLE
Update AGP to 9.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The plugin contains the following functionality:
 
 ```kotlin
 plugins {
-    id("ch.ubique.gradle.alpaka") version "9.2.0"
+    id("ch.ubique.gradle.alpaka") version "9.3.0"
 }
 ```
 

--- a/alpaka/gradle/wrapper/gradle-wrapper.properties
+++ b/alpaka/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.2.0"
+agp = "9.3.0"
 kotlin = "2.2.10"
 pluginPublish = "2.1.1"
 vanniktech = "0.36.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

- Android Gradle Plugin: 9.2.0 -> 9.3.0
- Gradle wrapper: 9.4.1 -> 9.5.0
- Plugin version reference in README: 9.2.0 -> 9.3.0

## Deprecation Warnings

The following deprecation warnings were detected during the local build and should be addressed in a follow-up:

Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10. Use assignment ('resValues = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/9.5.0/userguide/upgrading_version_8.html#groovy_space_assignment_syntax